### PR TITLE
Output passing steps in green

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -30,7 +30,7 @@ class CucumberReporter extends events.EventEmitter {
         })
 
         this.on('test:pass', (p) => {
-            this.printLine('bright pass', `${esc.sp}${esc.sp}${esc.sp}${esc.sp}${esc.sp}${esc.sp}${p.title}`)
+            this.printLine('green', `${esc.sp}${esc.sp}${esc.sp}${esc.sp}${esc.sp}${esc.sp}${p.title}`)
         })
 
         this.on('test:fail', (p) => {
@@ -63,7 +63,7 @@ class CucumberReporter extends events.EventEmitter {
         const total = results.failures + results.passes + results.pending
 
         process.stdout.write(color('suite', esc.nl + total + ' steps ('))
-        process.stdout.write(color('bright pass', results.passes + ' passed'))
+        process.stdout.write(color('green', results.passes + ' passed'))
         process.stdout.write(color('bright fail', ', ' + results.failures + ' failed'))
         process.stdout.write(color('pending', ', ' + results.pending + ' pending)' + esc.nl + esc.nl))
     }


### PR DESCRIPTION
Just a suggestion, as in my console (iterm2) the passing tests are printed in grey. This might be the default of the base reporter, but imho passing tests look better in green. ;)

Btw. thanks for the plugin! Really cool. 👍 
